### PR TITLE
delivery_timeカラムの削除

### DIFF
--- a/db/migrate/20200401083445_create_items.rb
+++ b/db/migrate/20200401083445_create_items.rb
@@ -9,7 +9,6 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer :preparation_day, null: false
       t.integer :exhibitor_id, foreign_key: true
       t.integer :buyer_id, foreign_key: true
-      t.string :delivery_time
       t.string :delivery_fee
       t.timestamps
     end


### PR DESCRIPTION
# What
delivery_timeカラムの削除。
# Why
preparation_dayと意味が同じため。