### PR TITLE
[WIP]Create_view_of_user_signin_in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@
 .byebug_history
 
 # Ignore master key for decrypting credentials and more.
+
 /config/master.key
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,7 +9,7 @@
 //
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
-//
+// 
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -1,0 +1,113 @@
+/*
+    TODO will need to remove settings on HTML since we can't namespace it.
+    TODO with the prefix, should I group by selector or property for weight savings?
+*/
+html{
+  color:#000;
+  background:#FFF;
+}
+/*
+  TODO remove settings on BODY since we can't namespace it.
+*/
+/*
+  TODO test putting a class on HEAD.
+      - Fails on FF.
+*/
+body,
+div,
+dl,
+dt,
+dd,
+ul,
+ol,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+textarea,
+p,
+blockquote,
+th,
+td {
+  margin:0;
+  padding:0;
+}
+table {
+  border-collapse:collapse;
+  border-spacing:0;
+}
+fieldset,
+img {
+  border:0;
+}
+/*
+  TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
+*/
+address,
+caption,
+cite,
+code,
+dfn,
+em,
+strong,
+th,
+var {
+  font-style:normal;
+  font-weight:normal;
+}
+
+ol,
+ul {
+  list-style:none;
+}
+
+caption,
+th {
+  text-align:left;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size:100%;
+  font-weight:normal;
+}
+q:before,
+q:after {
+  content:'';
+}
+abbr,
+acronym {
+  border:0;
+  font-variant:normal;
+}
+/* to preserve line-height and selector appearance */
+sup {
+  vertical-align:text-top;
+}
+sub {
+  vertical-align:text-bottom;
+}
+input,
+textarea,
+select {
+  font-family:inherit;
+  font-size:inherit;
+  font-weight:inherit;
+  *font-size:100%; /*to enable resizing for IE*/
+}
+/*because legend doesn't inherit in IE */
+legend {
+  color:#000;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,7 @@
  *
  * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
  * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
+ * 
  * You're free to add application-wide styles to this file and they'll appear at the bottom of the
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
  * files in this directory. Styles in this file should be added after the last require_* statement.
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+ @import "font-awesome-sprockets";
+ @import "font-awesome";

--- a/app/assets/stylesheets/user_login.scss
+++ b/app/assets/stylesheets/user_login.scss
@@ -1,0 +1,119 @@
+.user-login{
+  background-color: rgb(247, 247, 241);
+  &__header{
+    padding-top: 30px;
+    .logo-head{
+      display: block;
+      margin: 0px auto 30px auto;
+      width: 15vw;
+    }
+  }
+  &__main{
+    height: 100vh;
+    width:100vw;
+    &__panel{
+      height: 90vh;
+      width: 38vw;
+      margin-left: auto;
+      margin-right: auto;
+      margin-bottom:  60px;
+      padding-top: 30px;
+      color: rgb(37, 37, 37);
+      background-color: white;
+      text-align: center;
+      h1{
+        font-size: small;
+        font-weight: 300;
+        text-align: center;
+      }
+      &__facebook{
+        position: relative;
+        .facebook-icon{
+          position: absolute;
+          text-decoration: none;
+          color: white;
+          left: 25%;
+          top: 52%;
+        }
+        .login-facebook-btn{
+          position: relative;
+          height: 51px;
+          width: 25vw;
+          background-color: rgb(6, 6, 194);
+          color: white;
+          margin-top: 40px;
+          margin-bottom: 20px;
+          font-size: 15px;
+        }
+      }
+      &__google{
+        position: relative;
+        .google-icon{
+          position: absolute;
+          text-decoration: none;
+          color: black;
+          left: 25%;
+          top: 16%;
+        }
+        .login-google-btn{
+          height: 51px;
+          width: 25vw;
+          background-color: white;
+          color: black;
+          margin-bottom: 60px;
+          font-size: 15px;
+          border: solid 1px rgb(194, 186, 186);
+        }
+      }
+      #user_email{
+        height: 50px;
+        width: 25vw;
+        border-radius: 3px;
+        border: solid 1px rgb(194, 186, 186);
+        padding-left: 15px;
+        font-size: 15px;
+      }
+      #user_password{
+        height: 50px;
+        width: 25vw;
+        border-radius: 3px;
+        border: solid 1px rgb(194, 186, 186);
+        padding-left: 15px;
+        font-size: 15px;
+      }
+      .actions{       
+        .login-btn{
+        height: 50px;
+        width: 27vw;
+        color: white;
+        background-color: rgb(235, 2, 2);
+        margin-top: 20px;
+        margin-bottom: 100px;
+        font-size: 15px;
+        border: none;
+        }
+      }
+    }
+  }
+  .actions{
+    
+  }
+  .new-user-register-btn{
+    height: 40px;
+    width: 27vw;
+    color: white;
+    background-color: rgb(42, 180, 226);
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 10px;
+    padding-top: 20px;
+    display: block;
+    text-align: center;
+    text-decoration: none;
+    font-size: 15px;
+  }
+  .forget-password{
+    text-decoration: none;
+    color: gray;
+  }
+}

--- a/app/assets/stylesheets/user_signup.scss
+++ b/app/assets/stylesheets/user_signup.scss
@@ -1,0 +1,31 @@
+.user-signup{
+  background-color: rgb(247, 247, 241);
+  &__header{
+    padding-top: 30px;
+    .logo-head{
+      display: block;
+      margin: 0px auto 30px auto;
+      width: 15vw;
+    }
+  }
+  &__main{
+    background-color: white;
+    height: 60vh;
+    width: 38vw;
+    margin-left: auto;
+    margin-right: auto;
+    &__header{
+      text-align: center;
+      border-bottom: solid 1px gainsboro;
+      padding-top: 10px;
+      padding-bottom: 10px;
+      font-size: x-large;
+    }
+    &__forms{
+
+    }
+  }
+  &__footer{
+
+  }
+}

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend confirmation instructions
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
+  .actions
+    = f.submit "Resend confirmation instructions"
+= render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,0 +1,4 @@
+%p
+  Welcome #{@email}!
+%p You can confirm your account email through the link below:
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/devise/mailer/email_changed.html.haml
+++ b/app/views/devise/mailer/email_changed.html.haml
@@ -1,0 +1,8 @@
+%p
+  Hello #{@email}!
+- if @resource.try(:unconfirmed_email?)
+  %p
+    We're contacting you to notify you that your email is being changed to #{@resource.unconfirmed_email}.
+- else
+  %p
+    We're contacting you to notify you that your email has been changed to #{@resource.email}.

--- a/app/views/devise/mailer/password_change.html.haml
+++ b/app/views/devise/mailer/password_change.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hello #{@resource.email}!
+%p We're contacting you to notify you that your password has been changed.

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,0 +1,6 @@
+%p
+  Hello #{@resource.email}!
+%p Someone has requested a link to change your password. You can do this through the link below.
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
+%p If you didn't request this, please ignore this email.
+%p Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -1,0 +1,5 @@
+%p
+  Hello #{@resource.email}!
+%p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+%p Click the link below to unlock your account:
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,0 +1,19 @@
+%h2 Change your password
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  = f.hidden_field :reset_password_token
+  .field
+    = f.label :password, "New password"
+    %br/
+    - if @minimum_password_length
+      %em
+        (#{@minimum_password_length} characters minimum)
+      %br/
+    = f.password_field :password, autofocus: true, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation, "Confirm new password"
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Change my password"
+= render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Forgot your password?
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Send me reset password instructions"
+= render "devise/shared/links"

--- a/app/views/devise/registrations/_footer.html.haml
+++ b/app/views/devise/registrations/_footer.html.haml
@@ -1,0 +1,42 @@
+.footer
+  %ul.footer__lists
+    %li.footer__lists__list
+      %ul
+        %h3  
+          = link_to "FURIMAについて", "#"
+        %li
+          %p 
+            = link_to "会社概要（運営会社）", "#"
+        %li
+          %p 
+            = link_to "プライバシーポリシー", "#"
+        %li
+          %p 
+            = link_to "FURIMA利用規約", "#"
+        %li
+          %p 
+            = link_to "ポイントに関する特約", "#"
+      %ul
+        %h3 
+          = link_to "FURIMAを見る", "#"
+        %li
+          %p 
+            = link_to "カテゴリー一覧", "#"
+        %li
+          %p 
+            = link_to "ブランド一覧", "#"
+      %ul
+        %h3 
+          = link_to "ヘルプ＆ガイド", "#"
+        %li
+          %p 
+            = link_to "FURIMAガイド", "#"
+        %li
+          %p 
+            = link_to "FURIMAロゴ利用ガイドライン", "#"
+        %li
+          %p 
+            = link_to "お知らせ", "#"
+  .footer__logo
+    = link_to image_tag("logo-white.png",class:"logo"),"/"
+  %p © FURIMA

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,0 +1,36 @@
+%h2
+  Edit #{resource_name.to_s.humanize}
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+    %div
+      Currently waiting confirmation for: #{resource.unconfirmed_email}
+  .field
+    = f.label :password
+    %i (leave blank if you don't want to change it)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+    - if @minimum_password_length
+      %br/
+      %em
+        = @minimum_password_length
+        characters minimum
+  .field
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .field
+    = f.label :current_password
+    %i (we need your current password to confirm your changes)
+    %br/
+    = f.password_field :current_password, autocomplete: "current-password"
+  .actions
+    = f.submit "Update"
+%h3 Cancel my account
+%p
+  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+= link_to "Back", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,0 +1,29 @@
+.user-signup
+  .user-signup__header
+    = link_to image_tag("logo.png",class:"logo-head"),""
+  .user-signup__main
+    .user-signup__main__header
+      %h2 新規会員登録
+    .user-signup__main__forms
+      = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+        = render "devise/shared/error_messages", resource: resource
+        .field
+          = f.label :email
+          %br/
+          = f.email_field :email, autofocus: true, autocomplete: "email"
+        .field
+          = f.label :password
+          - if @minimum_password_length
+            %em
+              (#{@minimum_password_length} characters minimum)
+          %br/
+          = f.password_field :password, autocomplete: "new-password"
+        .field
+          = f.label :password_confirmation
+          %br/
+          = f.password_field :password_confirmation, autocomplete: "new-password"
+        .actions
+          = f.submit "Sign up"
+      = render "devise/shared/links"
+  .user-login__footer
+    = render "footer"

--- a/app/views/devise/sessions/_footer.html.haml
+++ b/app/views/devise/sessions/_footer.html.haml
@@ -1,0 +1,45 @@
+
+
+
+.footer
+  %ul.footer__lists
+    %li.footer__lists__list
+      %ul
+        %h3  
+          = link_to "FURIMAについて", "#"
+        %li
+          %p 
+            = link_to "会社概要（運営会社）", "#"
+        %li
+          %p 
+            = link_to "プライバシーポリシー", "#"
+        %li
+          %p 
+            = link_to "FURIMA利用規約", "#"
+        %li
+          %p 
+            = link_to "ポイントに関する特約", "#"
+      %ul
+        %h3 
+          = link_to "FURIMAを見る", "#"
+        %li
+          %p 
+            = link_to "カテゴリー一覧", "#"
+        %li
+          %p 
+            = link_to "ブランド一覧", "#"
+      %ul
+        %h3 
+          = link_to "ヘルプ＆ガイド", "#"
+        %li
+          %p 
+            = link_to "FURIMAガイド", "#"
+        %li
+          %p 
+            = link_to "FURIMAロゴ利用ガイドライン", "#"
+        %li
+          %p 
+            = link_to "お知らせ", "#"
+  .footer__logo
+    = link_to image_tag("logo-white.png",class:"logo"),"/"
+  %p © FURIMA

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,0 +1,30 @@
+.user-login
+  .user-login__header
+    = link_to image_tag("logo.png",class:"logo-head"),""
+  .user-login__main
+    .user-login__main__panel
+      .user-login__main__panel__facebook
+        = link_to "#", class:"facebook-link" do
+          %input.login-facebook-btn{:name => "confirm", :type => "submit", :value => "Facebookでログイン"}
+          = icon('fab', 'facebook-square', class:"facebook-icon")
+      .user-login__main__panel__google
+        = link_to "#", class:"google-link" do
+          %input.login-google-btn{:name => "confirm", :type => "submit", :value => "Googleでログイン"}
+          = icon('fab', 'google', class:"google-icon")
+      = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+        .field
+          %br/
+          = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス"
+        .field
+          %br/
+          = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード"
+        - if devise_mapping.rememberable?
+          .field
+            = f.check_box :remember_me
+            = f.label :remember_me
+        .actions
+          = f.submit "ログイン", class:"login-btn"
+          %h1 アカウントをお持ちでない方はこちら
+      = render "devise/shared/links"
+    .user-login__footer
+      = render "footer"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,0 +1,9 @@
+- if resource.errors.any?
+  #error_explanation
+    %h2
+      = I18n.t("errors.messages.not_saved",                 |
+        count: resource.errors.count,                       |
+        resource: resource.class.model_name.human.downcase) |
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,0 +1,19 @@
+- if controller_name != 'sessions'
+  = link_to "Log in", new_session_path(resource_name)
+  %br/
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "新規会員登録", new_registration_path(resource_name), class:"new-user-register-btn"
+  %br/
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class:"forget-password"
+  %br/
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  %br/
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %br/
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+    %br/

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend unlock instructions
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Resend unlock instructions"
+= render "devise/shared/links"


### PR DESCRIPTION
# what
ユーザーログインページのマークアップ
# why
ユーザーログインページの作成によりわかりやすいログインページを実現する
# NOTICE!!
![20f1fcf0189db4e0b944b436332b316f](https://user-images.githubusercontent.com/61730008/78539149-0ae71800-782d-11ea-9bb7-9f49fcb64127.png)

新規登録等ページ作成は機能面が実装しだい作成